### PR TITLE
Feature/add-move-all-notes-command

### DIFF
--- a/utils/RuleProcessor.ts
+++ b/utils/RuleProcessor.ts
@@ -17,7 +17,7 @@ export class RuleProcessor {
     for (const rule of this.rules) {
       if (this.ruleMatches(rule, fileMetadata)) {
         const path = this.processPathSpec(rule.pathSpec, fileMetadata.frontmatter);
-        if (path !== false) {
+        if (path) {
           return path;
         }
       }


### PR DESCRIPTION
Stolen from @jeffbeaulieu 's [PR in auto-note-mover](https://github.com/farux/obsidian-auto-note-mover/pull/62)

Add a command to run the organization rules on all notes int he vault.