### PR TITLE
Feature/complex conditions

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -47,9 +47,8 @@ export default class AutoNoteMover extends Plugin {
 			}
 
 			// transform pattern settings to Rules
-			const rules: Rule[] = folderTagPattern.map( ftp => ({
+			const rules: Rule[] = folderTagPattern.map(ftp => ({
 				tagMatch: ftp.tag,
-				titleMatchRegex: ftp.pattern?new RegExp(ftp.pattern):undefined,
 				pathSpec: ftp.folder
 			}));
 			

--- a/main.ts
+++ b/main.ts
@@ -49,7 +49,7 @@ export default class AutoNoteMover extends Plugin {
 			// transform pattern settings to Rules
 			const rules: Rule[] = folderTagPattern.map( ftp => ({
 				tagMatch: ftp.tag,
-				titleMatchRegex: new RegExp(ftp.pattern),
+				titleMatchRegex: ftp.pattern?new RegExp(ftp.pattern):undefined,
 				pathSpec: ftp.folder
 			}));
 			

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { MarkdownView, Plugin, TFile, getAllTags, Notice, TAbstractFile, normalizePath } from 'obsidian';
+import { MarkdownView, Plugin, TFile, getAllTags, Notice, TAbstractFile, normalizePath, debounce } from 'obsidian';
 import { DEFAULT_SETTINGS, AutoNoteMoverSettings, AutoNoteMoverSettingTab } from 'settings/settings';
 import { fileMove, getTriggerIndicator, isFmDisable } from 'utils/Utils';
 import { RuleProcessor, Rule, FileMetadata } from 'utils/RuleProcessor'
@@ -66,7 +66,7 @@ export default class AutoNoteMover extends Plugin {
 			const movePath = rp.getDestinationPath(fileMetadata);
 			if (movePath) {
 				console.log('movePath', movePath);
-				fileMove(this.app, movePath, fileFullName, file);
+				fileMove(this, movePath, fileFullName, file);
 			}
 		};
 
@@ -84,9 +84,9 @@ export default class AutoNoteMover extends Plugin {
 		}
 
 		this.app.workspace.onLayoutReady(() => {
-			this.registerEvent(this.app.vault.on('create', (file) => { console.log('new note'); fileCheck(file); }));
-			this.registerEvent(this.app.metadataCache.on('changed', (file) => fileCheck(file)));
-			this.registerEvent(this.app.vault.on('rename', (file, oldPath) => fileCheck(file, oldPath)));
+			this.registerEvent(this.app.vault.on('create', (file) => debounce(fileCheck, 200, true)(file)));
+			this.registerEvent(this.app.metadataCache.on('changed', (file) => debounce(fileCheck, 200, true)(file)));
+			this.registerEvent(this.app.vault.on('rename', (file, oldPath) => debounce(fileCheck, 200, true)(file, oldPath)));
 		});
 
 		const moveNoteCommand = (view: MarkdownView) => {

--- a/main.ts
+++ b/main.ts
@@ -64,8 +64,7 @@ export default class AutoNoteMover extends Plugin {
 				frontmatter: fileCache.frontmatter ?? { }
 			}
 
-			console.log('testing', fileName);
-			const movePath = rp.processFileMetadata(fileMetadata);
+			const movePath = rp.getDestinationPath(fileMetadata);
 			if (movePath) {
 				console.log('movePath', movePath);
 				fileMove(this.app, movePath, fileFullName, file);

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
 		"@typescript-eslint/parser": "^5.2.0",
 		"builtin-modules": "^3.2.0",
 		"esbuild": "0.13.12",
-		"obsidian": "^0.12.17",
+		"obsidian": "^1.4.11",
 		"tslib": "2.3.1",
 		"typescript": "4.4.4"
 	},
 	"dependencies": {
-		"@popperjs/core": "^2.11.2"
+		"@popperjs/core": "^2.11.2",
+		"logical-expression-parser": "^1.0.2"
 	}
 }

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -1,8 +1,7 @@
 import AutoNoteMover from 'main';
-import { App, Notice, PluginSettingTab, Setting, ButtonComponent } from 'obsidian';
+import { App, PluginSettingTab, Setting, ButtonComponent } from 'obsidian';
 
 import { FolderSuggest } from 'suggests/file-suggest';
-import { TagSuggest } from 'suggests/tag-suggest';
 import { arrayMove } from 'utils/Utils';
 
 export interface FolderTagPattern {
@@ -174,12 +173,6 @@ export class AutoNoteMoverSettingTab extends PluginSettingTab {
 			});
 
 		this.plugin.settings.folder_tag_pattern.forEach((folder_tag_pattern, index) => {
-			const settings = this.plugin.settings.folder_tag_pattern;
-			const settingTag = settings.map((e) => e['tag']);
-			const settingPattern = settings.map((e) => e['pattern']);
-			const checkArr = (arr: string[], val: string) => {
-				return arr.some((arrVal) => val === arrVal);
-			};
 
 			const s = new Setting(this.containerEl)
 				.addSearch((cb) => {
@@ -192,46 +185,17 @@ export class AutoNoteMoverSettingTab extends PluginSettingTab {
 						});
 				})
 
-				.addSearch((cb) => {
-					new TagSuggest(this.app, cb.inputEl);
-					cb.setPlaceholder('Tag')
+				.addText((cb) => {
+					// new TagSuggest(this.app, cb.inputEl);
+					
+					cb.setPlaceholder('Condition')
 						.setValue(folder_tag_pattern.tag)
 						.onChange(async (newTag) => {
-							if (this.plugin.settings.folder_tag_pattern[index].pattern) {
-								this.display();
-								return new Notice(`You can set either the tag or the title.`);
-							}
-							if (newTag && checkArr(settingTag, newTag)) {
-								new Notice('This tag is already used.');
-								return;
-							}
-							if (!this.plugin.settings.use_regex_to_check_for_tags) {
-								this.plugin.settings.folder_tag_pattern[index].tag = newTag.trim();
-							} else if (this.plugin.settings.use_regex_to_check_for_tags) {
-								this.plugin.settings.folder_tag_pattern[index].tag = newTag;
-							}
+							this.plugin.settings.folder_tag_pattern[index].tag = newTag.trim();
 							await this.plugin.saveSettings();
 						});
 				})
 
-				.addSearch((cb) => {
-					cb.setPlaceholder('Title by regex')
-						.setValue(folder_tag_pattern.pattern)
-						.onChange(async (newPattern) => {
-							if (this.plugin.settings.folder_tag_pattern[index].tag) {
-								this.display();
-								return new Notice(`You can set either the tag or the title.`);
-							}
-
-							if (newPattern && checkArr(settingPattern, newPattern)) {
-								new Notice('This pattern is already used.');
-								return;
-							}
-
-							this.plugin.settings.folder_tag_pattern[index].pattern = newPattern;
-							await this.plugin.saveSettings();
-						});
-				})
 				.addExtraButton((cb) => {
 					cb.setIcon('up-chevron-glyph')
 						.setTooltip('Move up')

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -49,30 +49,13 @@ export class AutoNoteMoverSettingTab extends PluginSettingTab {
 	}
 
 	add_auto_note_mover_setting(): void {
-		this.containerEl.createEl('h2', { text: 'Auto Note Mover' });
+		this.containerEl.createEl('h2', { text: 'Auto Note Organizer' });
 
 		const descEl = document.createDocumentFragment();
 
 		new Setting(this.containerEl).setDesc(
-			'Auto Note Mover will automatically move the active notes to their respective folders according to the rules.'
+			'Auto Note Organizer will automatically move the active notes to their respective folders according to the rules.'
 		);
-
-		/* new Setting(this.containerEl)
-			.setName('Auto Note Mover')
-			.setDesc('Enable or disable the Auto Note Mover.')
-			.addToggle((toggle) => {
-				toggle
-					.setValue(this.plugin.settings.enable_auto_note_mover)
-					.onChange(async (use_new_auto_note_mover) => {
-						this.plugin.settings.enable_auto_note_mover = use_new_auto_note_mover;
-						await this.plugin.saveSettings();
-						this.display();
-					});
-			});
-
-		if (!this.plugin.settings.enable_auto_note_mover) {
-			return;
-		} */
 
 		const triggerDesc = document.createDocumentFragment();
 		triggerDesc.append(
@@ -103,45 +86,39 @@ export class AutoNoteMoverSettingTab extends PluginSettingTab {
 					})
 			);
 
-		const useRegexToCheckForTags = document.createDocumentFragment();
-		useRegexToCheckForTags.append(
-			'If enabled, tags will be checked with regular expressions.',
-			descEl.createEl('br'),
-			'For example, if you want to match the #tag, you would write ',
-			descEl.createEl('strong', { text: '^#tag$' }),
-			descEl.createEl('br'),
-			'This setting is for a specific purpose, such as specifying nested tags in bulk.',
-			descEl.createEl('br'),
-			descEl.createEl('strong', {
-				text: 'If you want to use the suggested tags as they are, it is recommended to disable this setting.',
-			})
-		);
-		new Setting(this.containerEl)
-			.setName('Use regular expressions to check for tags')
-			.setDesc(useRegexToCheckForTags)
-			.addToggle((toggle) => {
-				toggle.setValue(this.plugin.settings.use_regex_to_check_for_tags).onChange(async (value) => {
-					this.plugin.settings.use_regex_to_check_for_tags = value;
-					await this.plugin.saveSettings();
-					this.display();
-				});
-			});
+		// const useRegexToCheckForTags = document.createDocumentFragment();
+		// useRegexToCheckForTags.append(
+		// 	'If enabled, tags will be checked with regular expressions.',
+		// 	descEl.createEl('br'),
+		// 	'For example, if you want to match the #tag, you would write ',
+		// 	descEl.createEl('strong', { text: '^#tag$' }),
+		// 	descEl.createEl('br'),
+		// 	'This setting is for a specific purpose, such as specifying nested tags in bulk.',
+		// 	descEl.createEl('br'),
+		// 	descEl.createEl('strong', {
+		// 		text: 'If you want to use the suggested tags as they are, it is recommended to disable this setting.',
+		// 	})
+		// );
+		// new Setting(this.containerEl)
+		// 	.setName('Use regular expressions to check for tags')
+		// 	.setDesc(useRegexToCheckForTags)
+		// 	.addToggle((toggle) => {
+		// 		toggle.setValue(this.plugin.settings.use_regex_to_check_for_tags).onChange(async (value) => {
+		// 			this.plugin.settings.use_regex_to_check_for_tags = value;
+		// 			await this.plugin.saveSettings();
+		// 			this.display();
+		// 		});
+		// 	});
 
 		const ruleDesc = document.createDocumentFragment();
 		ruleDesc.append(
 			'1. Set the destination folder.',
 			descEl.createEl('br'),
-			'2. Set a tag or title that matches the note you want to move. ',
-			descEl.createEl('strong', { text: 'You can set either the tag or the title. ' }),
+			'2. Create an expression that matches the note you want to move. ',
+			descEl.createEl('strong', { text: 'use and(&) or(|) not(!) and parens(()). use [] for values. `example: tag[nohash]&project[myproj]' }),
 			descEl.createEl('br'),
 			'3. The rules are checked in order from the top. The notes will be moved to the folder with the ',
 			descEl.createEl('strong', { text: 'first matching rule.' }),
-			descEl.createEl('br'),
-			'Tag: Be sure to add a',
-			descEl.createEl('strong', { text: ' # ' }),
-			'at the beginning.',
-			descEl.createEl('br'),
-			'Title: Tested by JavaScript regular expressions.',
 			descEl.createEl('br'),
 			descEl.createEl('br'),
 			'Notice:',

--- a/settings/settings.ts
+++ b/settings/settings.ts
@@ -21,6 +21,7 @@ export interface AutoNoteMoverSettings {
 	folder_tag_pattern: Array<FolderTagPattern>;
 	use_regex_to_check_for_excluded_folder: boolean;
 	excluded_folder: Array<ExcludedFolder>;
+	create_non_existent_folders: boolean;
 }
 
 export const DEFAULT_SETTINGS: AutoNoteMoverSettings = {
@@ -30,6 +31,7 @@ export const DEFAULT_SETTINGS: AutoNoteMoverSettings = {
 	folder_tag_pattern: [{ folder: '', tag: '', pattern: '' }],
 	use_regex_to_check_for_excluded_folder: false,
 	excluded_folder: [{ folder: '' }],
+	create_non_existent_folders: false,
 };
 
 export class AutoNoteMoverSettingTab extends PluginSettingTab {
@@ -201,6 +203,17 @@ export class AutoNoteMoverSettingTab extends PluginSettingTab {
 						});
 				});
 			s.infoEl.remove();
+		});
+
+		new Setting(this.containerEl)
+		.setName('Create Folders if they don\'t exist')
+		.setDesc('This can be especially useful when using capture groups in the destination folder.')
+		.addToggle((toggle) => {
+			toggle.setValue(this.plugin.settings.create_non_existent_folders).onChange(async (value) => {
+				this.plugin.settings.create_non_existent_folders = value;
+				await this.plugin.saveSettings();
+				this.display();
+			});
 		});
 
 		const useRegexToCheckForExcludedFolder = document.createDocumentFragment();

--- a/utils/RuleProcessor.ts
+++ b/utils/RuleProcessor.ts
@@ -3,7 +3,7 @@ import { parse } from 'logical-expression-parser';
 export interface Rule {
   pathSpec: string;
   tagMatch?: string; // todo: settings.use_regex_to_check_for_tags
-  titleMatchRegex?: RegExp;
+  // titleMatchRegex?: RegExp;
 }
 
 export interface FileMetadata {
@@ -28,11 +28,12 @@ export class RuleProcessor {
   }
   
   private parseTest(input: string): { parameter: string, value: string } {
-    const regex = /^(\w+)\[(\w+)\]$/;
+    const regex = /^(\w+)\[(\w+)\]$/; // something[else]
     const match = input.match(regex);
     if (match) {
         return { parameter: match[1], value: match[2] };
     }
+    // error
     return { parameter: '!!!', value: 'nfg' };
   }
 
@@ -71,22 +72,18 @@ export class RuleProcessor {
   }
 
   private ruleMatches(rule: Rule, fileMetadata: FileMetadata): boolean {
-    if (!rule.tagMatch && !rule.titleMatchRegex) {
+    if (!rule.tagMatch) {
+      // match everything
       return true;
     }
 
-    if (rule.tagMatch && rule.titleMatchRegex) {
-      return fileMetadata.tags.includes(rule.tagMatch) && rule.titleMatchRegex.test(fileMetadata.title);
-    }
     if (rule.tagMatch) {
       if (rule.tagMatch.startsWith('=')) {
-        return parse(rule.tagMatch.substring(1), (cond: string) => this.expressionEvaluator(cond, fileMetadata));
+        rule.tagMatch = rule.tagMatch.substring(1);
       }
-      return fileMetadata.tags.includes(rule.tagMatch);
+      return parse(rule.tagMatch, (cond: string) => this.expressionEvaluator(cond, fileMetadata));
     }
-    if (rule.titleMatchRegex) {
-      return rule.titleMatchRegex.test(fileMetadata.title);
-    }
+    
     return false;
   }
 

--- a/utils/RuleProcessor.ts
+++ b/utils/RuleProcessor.ts
@@ -13,7 +13,7 @@ export interface FileMetadata {
 export class RuleProcessor {
   constructor(private rules: Rule[]) {}
 
-  processFileMetadata(fileMetadata: FileMetadata): string | false {
+  getDestinationPath(fileMetadata: FileMetadata): string | false {
     for (const rule of this.rules) {
       if (this.ruleMatches(rule, fileMetadata)) {
         const path = this.processPathSpec(rule.pathSpec, fileMetadata.frontmatter);

--- a/utils/Utils.ts
+++ b/utils/Utils.ts
@@ -1,3 +1,4 @@
+import AutoNoteMover from 'main';
 import { App, CachedMetadata, normalizePath, Notice, parseFrontMatterEntry, TFile, TFolder } from 'obsidian';
 
 // Disable AutoNoteMover when "AutoNoteMover: disable" is present in the frontmatter.
@@ -27,12 +28,18 @@ const isTFExists = (app: App, path: string, F: typeof TFile | typeof TFolder) =>
 	}
 };
 
-export const fileMove = async (app: App, settingFolder: string, fileFullName: string, file: TFile) => {
+export const fileMove = async (plugin: AutoNoteMover, settingFolder: string, fileFullName: string, file: TFile) => {
+	const { app, settings } = plugin;
 	// Does the destination folder exist?
 	if (!isTFExists(app, settingFolder, TFolder)) {
-		console.error(`[Auto Note Mover] The destination folder "${settingFolder}" does not exist.`);
-		new Notice(`[Auto Note Mover]\n"Error: The destination folder\n"${settingFolder}"\ndoes not exist.`);
-		return;
+		if (settings.create_non_existent_folders) {
+			console.log(`[Auto Note Mover] Creating folder: ${settingFolder}`);
+			await app.vault.createFolder(normalizePath(settingFolder));
+		} else {
+			console.error(`[Auto Note Mover] The destination folder "${settingFolder}" does not exist.`);
+			new Notice(`[Auto Note Mover]\n"Error: The destination folder\n"${settingFolder}"\ndoes not exist.`);
+			return;
+		}
 	}
 	// Does the file with the same name exist in the destination folder?
 	const newPath = normalizePath(settingFolder + '/' + fileFullName);


### PR DESCRIPTION
Condition expressions like `tag[myTag]&has[project]&project[myProj]` - uses `https://www.npmjs.com/package/logical-expression-parser`

debounce rule checks and optionally create destination folder if no exist. Borrowed from https://github.com/farux/obsidian-auto-note-mover/pull/42