### PR TITLE
Update RuleProcessor.ts

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "auto-note-organizer",
 	"name": "Auto Note Organizer",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"minAppVersion": "0.12.0",
 	"description": "Auto Note Organizer will automatically move the active notes to their respective folders according to the rules.",
 	"author": "brosell",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"esbuild": "0.13.12",
 		"obsidian": "^1.4.11",
 		"tslib": "2.3.1",
-		"typescript": "4.4.4"
+		"typescript": "^5.4.2"
 	},
 	"dependencies": {
 		"@popperjs/core": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "auto-note-organizer",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "Auto Note Organizer will automatically move the active notes to their respective folders according to the rules. (fork of farux/obsidian-auto-note-mover)",
 	"main": "main.js",
 	"scripts": {

--- a/utils/RuleProcessor.ts
+++ b/utils/RuleProcessor.ts
@@ -28,7 +28,7 @@ export class RuleProcessor {
   }
   
   private parseTest(input: string): { parameter: string, value: string } {
-    const regex = /^(\w+)\[(\w+)\]$/; // something[else]
+    const regex = /^(\w+)\[(.+)\]$/; // attribute[value]
     const match = input.match(regex);
     if (match) {
         return { parameter: match[1], value: match[2] };


### PR DESCRIPTION
fix: a rule like "attr[value]" parser regexp. values can contain any symbols including emojis, not just "[\w]" character class.
